### PR TITLE
Fix AABB missing constructor

### DIFF
--- a/include/muli/aabb.h
+++ b/include/muli/aabb.h
@@ -8,6 +8,11 @@ namespace muli
 struct AABB
 {
     AABB() = default;
+    AABB(const Vec2& _min, const Vec2& _max)
+        : min(_min)
+        , max(_max){
+
+        };
 
     Vec2 GetCenter() const
     {


### PR DESCRIPTION
Muli was throwing the following compile errors on my project

![image](https://github.com/Sopiro/Muli/assets/4944278/854494e9-f137-4142-9db9-95652b6f5dd0)

By adding a constructor that accepts the 2 vectors, it can now successfully compile 💖